### PR TITLE
Remove websites that redirect off of roboring

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -90,20 +90,6 @@
         "owner": "https://social.treehouse.systems/@melody_notpond"
     },
     {
-        "name": "0x191E32 \"elke\"",
-        "slug": "0x191E32",
-        "about": "barista-robot turned weird-cat-thing on the internet",
-        "url": "https://elke.cafe",
-        "owner": "https://tapenoise.cafe/@ijomeli"
-    },
-    {
-        "name": "Junko",
-        "slug": "junko",
-        "about": "combat robomaid exploring the edges of reality",
-        "url": "https://lavenderfield.xyz",
-        "owner": "https://ak.lavenderfield.xyz/jvnkyard"
-    },
-    {
         "name": "beeps",
         "slug": "beeps",
         "about": "Web developer, plural, robot furry kinda just posts about whatever. ",


### PR DESCRIPTION
Really annoying to deal with when I can't do shit about it. Not everyone has total control over what web browser they can use and switching to another one just to view some random user's page is annoying.