### PR TITLE
append natalieee.net and its associated natalie[ee] to webring

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -198,5 +198,12 @@
         "about": "mel's home site, where it stores information about its identity",
         "url": "https://meluhdy.dev",
         "owner": "https://mk.moth.zone/@melody"
+    },
+    {
+        "name": "natalie[ee]",
+        "slug": "0x6e6174",
+        "about": "website in which natalie complains and ocassionaly doesn't explain incomprehensible computer programs",
+        "url": "https://natalieee.net",
+        "owner": "https://natalieee.net/files/nrc.vcf"
     }
 ]


### PR DESCRIPTION
as of https://github.com/0x6e6174/htmlgen/commit/79a588fa06a2dccabd55d7171da405eaaa4147ff, its website displays the relevant forward and backward webring navigation links.

beep boop.