### PR TITLE
Update beeps' fediverse link

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -114,10 +114,10 @@
     {
         "name": "beeps",
         "slug": "beeps",
-        "about": "Web developer, plural, robot furry kinda just posts about whatever. ",
+        "about": "Web developer, plural, robot furry kinda just posts about whatever.",
         "url": "https://beeps.website",
         "rss": "https://beeps.website/feed.xml",
-        "owner": "https://chitter.xyz/@batbeeps"
+        "owner": "https://social.beeps.gay/@beeps"
     },
     {
         "name": "nelle observer",


### PR DESCRIPTION
I moved to a self-hosted Mastodon instance recently, so the fediverse link used to identify ownership is out of date.

## Changes
- Update my 'owner' link to point to my new instance and username.
- Remove a little excess whitespace on the about text.