### PR TITLE
noelle: Update Mastodon URL

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -38,7 +38,7 @@
         "slug": "noelle",
         "about": "Noelle's personal website for writing and reference",
         "url": "https://noelle.dev",
-        "owner": "https://tech.lgbt/@noelle"
+        "owner": "https://mastodon.noelle.dev/@noelle"
     },
     {
         "name": "sophia",


### PR DESCRIPTION
Moved from https://tech.lgbt/@noelle to https://mastodon.noelle.dev/@noelle