### PR TITLE
styles.css: Hide <pre> scrollbars when unnecessary

### DIFF
--- a/data/assets/styles.css
+++ b/data/assets/styles.css
@@ -95,7 +95,7 @@ li {
 pre {
     font-family: 'jetbrains mono', monospace;
     white-space: nowrap;
-    overflow-x: scroll;
+    overflow-x: auto;
     border: 1px solid #666;
     border-radius: 8px;
     padding: 1em;


### PR DESCRIPTION
Changes [`overflow-x`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x) on `pre` elements from [`scroll`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x#scroll) to [`auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x#auto). 

This hides the empty scrollbars when the container is wide enough that scrolling is not needed.